### PR TITLE
Fix rolling water sensor metadata

### DIFF
--- a/custom_components/brunata_online/sensor.py
+++ b/custom_components/brunata_online/sensor.py
@@ -737,6 +737,14 @@ class BrunataLastDaysConsumptionSensor(BrunataMeterSensor):
         return SensorStateClass.MEASUREMENT
 
     @property
+    def device_class(self) -> SensorDeviceClass | None:
+        # Rolling window consumption is not a monotonic water total, so it
+        # must not advertise the water device class.
+        if _is_heating_medium(self._meter_medium) and self._native_unit == "kWh":
+            return SensorDeviceClass.ENERGY
+        return None
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         attrs = dict(super().extra_state_attributes)
         points = _history_points_for_meter(self.coordinator.data, self._meter_key)
@@ -860,6 +868,11 @@ class BrunataAggregateWaterLastDaysSensor(_BrunataAggregateWaterBase):
     @property
     def native_value(self):
         return _sum_window_deltas(self.coordinator.data, self._rows, self._window_days)
+
+    @property
+    def device_class(self) -> SensorDeviceClass | None:
+        # These are period deltas, not cumulative water totals.
+        return None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
This fixes sensor metadata for rolling water consumption sensors.

What changed:
- removes `device_class=water` from rolling per-meter water consumption sensors such as `last 1/7/14/30 days`
- removes `device_class=water` from rolling aggregate water consumption sensors
- keeps `device_class=water` on cumulative total water sensors only
- keeps `device_class=energy` on rolling heating kWh sensors where that still fits the measurement semantics

Why:
The rolling water sensors represent period deltas and use `state_class=measurement`. Advertising them as `device_class=water` causes Home Assistant warnings because that device class is meant for cumulative water totals, not windowed deltas.

This change keeps the useful total water sensors compatible with Energy/Water dashboards while avoiding warnings for overview-style rolling consumption sensors.

This PR intentionally limits itself to sensor metadata and does not change auth behavior.