### PR TITLE
Fix water totals after transmitter replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Output files:
    - Integration needs sufficient daily points.
    - First refresh may expose empty `last N days` until history cache is filled.
 
+4. **A water transmitter was replaced**
+   - Brunata may stop returning a current value for the old transmitter while
+     the new transmitter reports only consumption since the exchange.
+   - The total sensors retain the old transmitter's latest historical reading
+     as the baseline and add the replacement transmitter's reading.
+
 ---
 
 ## Maintainer: Tag + Release

--- a/custom_components/brunata_online/manifest.json
+++ b/custom_components/brunata_online/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/patricklind/brunata-to-home-assistant/issues",
   "loggers": ["custom_components.brunata_online"],
   "requirements": ["requests>=2.31.0"],
-  "version": "1.0.20"
+  "version": "1.0.21"
 }

--- a/custom_components/brunata_online/sensor.py
+++ b/custom_components/brunata_online/sensor.py
@@ -234,6 +234,34 @@ def _history_delta(points: list[dict[str, Any]]) -> float | None:
     return round(delta, 3)
 
 
+def _latest_history_value(points: list[dict[str, Any]]) -> float | int | None:
+    """Return the newest usable cumulative value from meter history."""
+    for point in reversed(points):
+        value = _normalize_reading_value(point.get("value"))
+        if value is not None:
+            return value
+    return None
+
+
+def _current_or_history_value(
+    coordinator_data: dict[str, Any] | None, row: dict[str, Any]
+) -> float | int | None:
+    """Return the current reading, falling back to the last historical total.
+
+    Brunata can leave the current reading empty for a dismounted transmitter.
+    Its final value still forms the baseline of the physical meter total after a
+    replacement transmitter starts reporting the subsequent consumption.
+    """
+    reading = row.get("reading") if isinstance(row.get("reading"), dict) else {}
+    current_value = _normalize_reading_value(reading.get("value"))
+    if current_value is not None:
+        return current_value
+
+    meter_key = _row_key(row)
+    points = _history_points_for_meter(coordinator_data, meter_key)
+    return _latest_history_value(points)
+
+
 def _window_label(days: int) -> str:
     return "1 day" if days == 1 else f"{days} days"
 
@@ -339,12 +367,13 @@ def _rows_for_mediums(
     return result
 
 
-def _sum_current_values(rows: list[dict[str, Any]]) -> float | None:
+def _sum_current_values(
+    coordinator_data: dict[str, Any] | None, rows: list[dict[str, Any]]
+) -> float | None:
     total = 0.0
     count = 0
     for row in rows:
-        reading = row.get("reading") if isinstance(row.get("reading"), dict) else {}
-        value = _normalize_reading_value(reading.get("value"))
+        value = _current_or_history_value(coordinator_data, row)
         if value is None:
             continue
         total += float(value)
@@ -525,8 +554,7 @@ class BrunataMeterSensor(CoordinatorEntity[BrunataDataCoordinator], SensorEntity
         row = self._current_row
         if not row:
             return None
-        reading = row.get("reading") if isinstance(row.get("reading"), dict) else {}
-        return _normalize_reading_value(reading.get("value"))
+        return _current_or_history_value(self.coordinator.data, row)
 
     @property
     def native_unit_of_measurement(self) -> str | None:
@@ -836,7 +864,7 @@ class BrunataAggregateWaterTotalSensor(_BrunataAggregateWaterBase):
 
     @property
     def native_value(self):
-        return _sum_current_values(self._rows)
+        return _sum_current_values(self.coordinator.data, self._rows)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation

- Ensure total water sensors remain correct when Brunata stops returning a current reading for a replaced transmitter by using the last valid historical cumulative value as the baseline.

### Description

- Add `_latest_history_value` and `_current_or_history_value` helpers to prefer a meter's current reading and fall back to the newest usable historical cumulative reading. 
- Apply the fallback to per-meter sensors (`BrunataMeterSensor.native_value`) and to aggregate water totals by threading `coordinator.data` into `_sum_current_values` and using `_current_or_history_value` for each row. 
- Document transmitter-replacement behavior in `README.md`. 
- Bump integration version to `1.0.21` in `custom_components/brunata_online/manifest.json`.

### Testing

- `git diff --check` — succeeded.
- `python -m compileall -q custom_components fetch_brunata_data.py` — succeeded.
- `python -m black --check custom_components/brunata_online/sensor.py` — succeeded (no formatting changes required).
- `pre-commit run --config .github/pre-commit.yml --all-files --show-diff-on-failure --color=never` — not run due to `pre-commit` not available in the environment (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79af85d3d48328abf4ee971a4046c1)