### PR TITLE
Harden authentication, startup lifecycle, history caching and numeric validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Standalone diagnostic script credentials. Never commit real values.
+BRUNATA_USERNAME=your-account@example.com
+BRUNATA_PASSWORD=replace-me

--- a/README.md
+++ b/README.md
@@ -157,10 +157,41 @@ Environment variables (from `.env`):
 - `BRUNATA_USERNAME`
 - `BRUNATA_PASSWORD`
 
+Copy `.env.example` to `.env` and replace the placeholders. The ignored `.env`
+file and generated `output/` directory can contain credentials or personal meter
+data and must not be committed or shared.
+
 Output files:
 
 - `output/brunata_data.json`
 - `output/brunata_meters.csv`
+
+## Development and verification
+
+The integration has no database, server process, or standalone web UI. Home
+Assistant supplies the async HTTP session, scheduling, entity registry, storage,
+and UI. The only direct runtime dependency in this repository is for the optional
+diagnostic script; Home Assistant installs the integration requirement declared
+in `manifest.json`.
+
+Use Python 3.12 or newer (matching current supported Home Assistant releases):
+
+```bash
+python -m pip install -r requirements.txt
+python -m unittest discover -s tests -v
+python -m compileall -q custom_components fetch_brunata_data.py tests
+```
+
+Maintainer checks mirror CI:
+
+```bash
+python -m pip install pre-commit black flake8
+pre-commit run --config .github/pre-commit.yml --all-files
+```
+
+Live authentication and meter retrieval require a real Brunata account and
+outbound access to `https://online.brunata.com`; unit tests do not make network
+requests.
 
 ---
 

--- a/custom_components/brunata_online/__init__.py
+++ b/custom_components/brunata_online/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
@@ -39,12 +39,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: BrunataConfigEntry) -> b
     )
 
     coordinator = BrunataDataCoordinator(hass, client)
-    await coordinator.async_refresh()
-    if not coordinator.last_update_success:
-        _LOGGER.warning(
-            "Initial Brunata refresh failed during setup; integration will retry in "
-            "background."
-        )
+    # Let Home Assistant distinguish temporary startup failures (which are
+    # retried as ConfigEntryNotReady) from invalid credentials. Continuing with
+    # an empty coordinator makes setup appear successful while exposing no
+    # entities and prevents Home Assistant's normal repair flow from running.
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
@@ -76,6 +75,8 @@ class BrunataDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             return await self.client.async_fetch_data()
         except BrunataAuthError as err:
-            raise UpdateFailed(f"Authentication failed: {err}") from err
+            raise ConfigEntryAuthFailed(
+                "Brunata credentials are no longer valid"
+            ) from err
         except Exception as err:  # pylint: disable=broad-except
             raise UpdateFailed(f"Failed to update Brunata data: {err}") from err

--- a/custom_components/brunata_online/api.py
+++ b/custom_components/brunata_online/api.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 import hashlib
 import html
+import math
 import re
 import secrets
 import time
@@ -348,7 +349,11 @@ class BrunataOnlineClient:
             history.setdefault(meter_key, [])
 
         self._history_cache = history
-        self._history_updated_at = now_utc
+        # A partial result is useful, but must not be considered fresh for 12
+        # hours. Keep the previous timestamp so the next coordinator update can
+        # promptly retry failed days.
+        if failed_days == 0:
+            self._history_updated_at = now_utc
 
         return history, {
             "days_back": HISTORY_DAYS_BACK,
@@ -482,6 +487,7 @@ class BrunataOnlineClient:
                 # Match the browser app; Brunata uses a long hex PKCE verifier.
                 code_verifier = secrets.token_hex(48)
                 code_challenge = _pkce_s256_challenge(code_verifier)
+                oauth_state = secrets.token_urlsafe(32)
 
                 with requests.Session() as session:
                     session.headers.update(DEFAULT_HEADERS)
@@ -494,6 +500,7 @@ class BrunataOnlineClient:
                         "redirect_uri": REDIRECT_URI,
                         "scope": OAUTH_SCOPE,
                         "response_type": "code",
+                        "state": oauth_state,
                         "code_challenge": code_challenge,
                         "code_challenge_method": "S256",
                     }
@@ -538,6 +545,7 @@ class BrunataOnlineClient:
 
                     redirect_location = login.headers.get("Location", "")
                     parsed = urllib.parse.urlparse(redirect_location)
+                    _validate_auth_redirect(parsed, oauth_state)
                     code = (urllib.parse.parse_qs(parsed.query).get("code") or [None])[
                         0
                     ]
@@ -568,7 +576,7 @@ class BrunataOnlineClient:
                         return resp.json()
 
                     raise BrunataAuthError(
-                        f"Token exchange failed ({resp.status_code}: {resp.text[:300]})"
+                        f"Token exchange failed (HTTP {resp.status_code})"
                     )
             except BrunataAuthError:
                 raise
@@ -714,7 +722,8 @@ def _to_float(value: Any) -> float | None:
     if value is None or isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
+        number = float(value)
+        return number if math.isfinite(number) else None
     if isinstance(value, str):
         text = value.strip().replace(" ", "")
         if not text:
@@ -727,7 +736,8 @@ def _to_float(value: Any) -> float | None:
         elif "," in text:
             text = text.replace(",", ".")
         try:
-            return float(text)
+            number = float(text)
+            return number if math.isfinite(number) else None
         except ValueError:
             return None
     return None
@@ -749,6 +759,27 @@ def _to_date(value: Any) -> date | None:
 def _pkce_s256_challenge(code_verifier: str) -> str:
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _validate_auth_redirect(
+    parsed: urllib.parse.ParseResult, expected_state: str
+) -> None:
+    """Validate the OAuth redirect target and anti-forgery state value."""
+    expected = urllib.parse.urlparse(REDIRECT_URI)
+    try:
+        port = parsed.port
+    except ValueError as err:
+        raise BrunataAuthError("Keycloak returned an invalid redirect") from err
+    query = urllib.parse.parse_qs(parsed.query)
+    returned_state = (query.get("state") or [None])[0]
+    if (
+        parsed.scheme != expected.scheme
+        or parsed.hostname != expected.hostname
+        or port not in {None, 443}
+        or parsed.path != expected.path
+        or not secrets.compare_digest(str(returned_state or ""), expected_state)
+    ):
+        raise BrunataAuthError("Keycloak returned an invalid redirect")
 
 
 def _extract_login_form_action(page_html: str) -> str:

--- a/custom_components/brunata_online/manifest.json
+++ b/custom_components/brunata_online/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/patricklind/brunata-to-home-assistant/issues",
   "loggers": ["custom_components.brunata_online"],
   "requirements": ["requests>=2.31.0"],
-  "version": "1.0.21"
+  "version": "1.0.22"
 }

--- a/custom_components/brunata_online/sensor.py
+++ b/custom_components/brunata_online/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+import math
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -111,10 +112,10 @@ def _heating_format(medium: str, native_unit: str | None) -> str | None:
 
 def _normalize_reading_value(value: Any) -> float | int | None:
     """Normalize Brunata reading values to numeric values for statistics."""
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return value
+        return value if math.isfinite(value) else None
     if isinstance(value, str):
         text = value.strip().replace(" ", "")
         if not text:
@@ -128,7 +129,8 @@ def _normalize_reading_value(value: Any) -> float | int | None:
             # Brunata may return decimal-comma values for water readings.
             text = text.replace(",", ".")
         try:
-            return float(text)
+            number = float(text)
+            return number if math.isfinite(number) else None
         except ValueError:
             return None
     return None

--- a/fetch_brunata_data.py
+++ b/fetch_brunata_data.py
@@ -94,6 +94,27 @@ def _validate_credential_post_url(url: str) -> None:
         raise BrunataAuthError("Keycloak returned an unsafe credential form URL")
 
 
+def _validate_auth_redirect(
+    parsed: urllib.parse.ParseResult, expected_state: str
+) -> None:
+    """Validate the OAuth redirect target and anti-forgery state value."""
+    expected = urllib.parse.urlparse(REDIRECT_URI)
+    try:
+        port = parsed.port
+    except ValueError as err:
+        raise BrunataAuthError("Keycloak returned an invalid redirect") from err
+    query = urllib.parse.parse_qs(parsed.query)
+    returned_state = (query.get("state") or [None])[0]
+    if (
+        parsed.scheme != expected.scheme
+        or parsed.hostname != expected.hostname
+        or port not in {None, 443}
+        or parsed.path != expected.path
+        or not secrets.compare_digest(str(returned_state or ""), expected_state)
+    ):
+        raise BrunataAuthError("Keycloak returned an invalid redirect")
+
+
 def _extract_keycloak_error_text(page_html: str) -> str | None:
     """Extract the inline error from a re-rendered Keycloak login page."""
     patterns = (
@@ -126,6 +147,7 @@ def authenticate(username: str, password: str) -> tuple[requests.Session, TokenD
 
     code_verifier = secrets.token_hex(48)
     code_challenge = _pkce_s256_challenge(code_verifier)
+    oauth_state = secrets.token_urlsafe(32)
 
     # 1. Load the Keycloak login page (sets AUTH_SESSION_ID / KC_RESTART cookies).
     login_page = session.get(
@@ -135,6 +157,7 @@ def authenticate(username: str, password: str) -> tuple[requests.Session, TokenD
             "redirect_uri": REDIRECT_URI,
             "scope": OAUTH_SCOPE,
             "response_type": "code",
+            "state": oauth_state,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         },
@@ -162,6 +185,7 @@ def authenticate(username: str, password: str) -> tuple[requests.Session, TokenD
 
     redirect_location = login.headers.get("Location", "")
     parsed = urllib.parse.urlparse(redirect_location)
+    _validate_auth_redirect(parsed, oauth_state)
     code = (urllib.parse.parse_qs(parsed.query).get("code") or [None])[0]
     if not code:
         raise BrunataAuthError("Authorization code missing in redirect")
@@ -186,9 +210,7 @@ def authenticate(username: str, password: str) -> tuple[requests.Session, TokenD
         timeout=REQUEST_TIMEOUT,
     )
     if resp.status_code >= 400:
-        raise BrunataAuthError(
-            f"Token exchange failed ({resp.status_code}: {resp.text[:300]})"
-        )
+        raise BrunataAuthError(f"Token exchange failed (HTTP {resp.status_code})")
 
     tokens = resp.json()
     access_token = tokens.get("access_token")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,27 @@ class CredentialPostUrlTests(unittest.TestCase):
                 api._validate_credential_post_url(url)
 
 
+class AuthorizationRedirectTests(unittest.TestCase):
+    """Ensure authorization codes are accepted only from the initiated flow."""
+
+    def test_accepts_expected_redirect_and_state(self) -> None:
+        parsed = api.urllib.parse.urlparse(
+            f"{api.REDIRECT_URI}?code=authorization-code&state=expected"
+        )
+        api._validate_auth_redirect(parsed, "expected")
+
+    def test_rejects_wrong_target_or_state(self) -> None:
+        unsafe_urls = (
+            f"{api.REDIRECT_URI}?code=value&state=wrong",
+            "https://evil.example/callback?code=value&state=expected",
+            "https://online.brunata.com/other?code=value&state=expected",
+            "http://online.brunata.com/mybrunata/auth-redirect?state=expected",
+        )
+        for url in unsafe_urls:
+            with self.subTest(url=url), self.assertRaises(api.BrunataAuthError):
+                api._validate_auth_redirect(api.urllib.parse.urlparse(url), "expected")
+
+
 class HistoryCacheTests(unittest.IsolatedAsyncioTestCase):
     """Verify partial history refreshes do not erase valid cached totals."""
 
@@ -109,6 +130,7 @@ class HistoryCacheTests(unittest.IsolatedAsyncioTestCase):
         history, metadata = await client._get_meter_history_30d([row])
 
         self.assertGreater(metadata["failed_days"], 0)
+        self.assertIsNone(client._history_updated_at)
         self.assertEqual(
             [point["date"] for point in history[meter_key]],
             [cached_day, today.isoformat()],
@@ -196,6 +218,11 @@ class HistoryFallbackTests(unittest.TestCase):
 
     def test_boolean_is_not_a_valid_meter_value(self) -> None:
         self.assertIsNone(api._to_float(True))
+
+    def test_non_finite_numbers_are_not_valid_meter_values(self) -> None:
+        for value in (float("nan"), float("inf"), "-inf"):
+            with self.subTest(value=value):
+                self.assertIsNone(api._to_float(value))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure OAuth authorization codes are bound to the initiated flow and reduce risk of processing unexpected redirects during token exchange.
- Surface expired/invalid credentials to Home Assistant so it can trigger the standard reauthentication/repair flow instead of silently appearing as a loaded integration with no entities.
- Avoid treating partial history fetches as fresh cache and prevent invalid numeric readings (booleans, NaN, infinities) from corrupting sensor aggregates.

### Description
- Validate OAuth redirects and anti-forgery `state` before exchanging authorization codes and stop including raw token-response bodies in raised errors; implemented in `custom_components/brunata_online/api.py` and mirrored in `fetch_brunata_data.py` via `_validate_auth_redirect` and sending a random `state` with the authorize request.
- Use Home Assistant first-refresh lifecycle by calling `async_config_entry_first_refresh()` during setup and raise `ConfigEntryAuthFailed` for authentication errors so HA can surface reauthentication; changes in `custom_components/brunata_online/__init__.py`.
- Keep partial history refresh results but only advance the history freshness timestamp when a full refresh succeeds so failed days are retried promptly; change in `custom_components/brunata_online/api.py` history handling.
- Reject boolean and non-finite numeric values at both API normalization and sensor normalization layers by updating `_to_float` and `_normalize_reading_value` to use `math.isfinite`, and add regression tests and docs plus `.env.example` and a version bump to `1.0.22`.

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests -v`, which executed 10 tests and all passed (10/10).
- Verified Python sources compile with `python -m compileall -q custom_components fetch_brunata_data.py tests` which completed successfully.
- Ran formatting with `black .` and confirmed `black --check .` passes after reformatting modified files.
- Added/updated regression tests in `tests/test_api.py` that cover redirect/state validation, partial-history freshness, and rejection of boolean/NaN/inf readings, and these tests passed in the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f124c98bc83288eaeabec6a7fc035)